### PR TITLE
extract_from_gs1_digital_link no longer errors out on invalid short codes

### DIFF
--- a/gs1/decompress/analyse_uri.py
+++ b/gs1/decompress/analyse_uri.py
@@ -52,7 +52,7 @@ def extract_from_gs1_digital_link(gs1_digital_link_uri):
         if i % 2 == 0:
             k = split_path[i]
             if not REGEX_ALL_NUM.match(split_path[i]):
-                k = SHORT_CODE_TO_NUMERIC[k]
+                k = SHORT_CODE_TO_NUMERIC.get(k, None)
             ai_sequence.append(k)
     ai_sequence = ai_sequence[::-1]
 


### PR DESCRIPTION
Discovered a bug where gs1.decompress.analyse_uri.extract_from_gs1_digital_link was throwing a KeyError exception when passed a uri that contains an invalid short code (eg, https://id.gs1.org/asdf?tes=34, https://id.gs1.org/asdf/42424xcv/?tes=34&gtin=50123456112013). This is not the same behavior as the original js version, which continues as if it didn't exist.

Not 100% sure on what the specs say is the proper way to go