### PR TITLE
extract_from_element_strings index error bugfix

### DIFF
--- a/gs1/compress/extract_from_element_strings.py
+++ b/gs1/compress/extract_from_element_strings.py
@@ -57,8 +57,11 @@ def extract_from_element_strings(element_strings: str):
                 length = FIXED_LENGTH_TABLE.get(first_two_digits)
                 buffer.append(element_strings[cursor:cursor + length])
                 cursor += length
+                # If there are no more characters, continue
+                if cursor >= element_strings_length:
+                    continue
                 # If the next character is the group separator, move past
-                if element_strings[cursor] == group_separator:
+                elif element_strings[cursor] == group_separator:
                     cursor += 1
             else:
                 # The first two digits are not within the array of GS1

--- a/tests/compress/test_core_functions.py
+++ b/tests/compress/test_core_functions.py
@@ -20,6 +20,8 @@ class TestCentralFunctions(TestCase):
         self.element_string = "(01)00614141123452(3103)000500"
         self.element_string_no_bracket = (
                 "3103000189010541234500001339232172" + '\x1d' + '10ABC123')
+        self.element_string_fixed_length = (
+            "0100614141123452")
 
     def test_compress_gs1_digital_link(self):
         """Test compressing a digital link."""
@@ -50,3 +52,9 @@ class TestCentralFunctions(TestCase):
             False, False)
         self.assertEqual(result_no_bracket,
                          'https://id.gs1.org/AQnYUc1gmiCNV4JGYgYAF6ckaEPg')
+
+        result_element_string_fixed_length = element_string_to_compressed_gs1_digital_link(
+            self.element_string_fixed_length, False, 'https://id.gs1.org',
+            False, False)
+        self.assertEqual(result_element_string_fixed_length,
+                         'https://id.gs1.org/AQEd-1O2-A')


### PR DESCRIPTION
There was an `IndexError` being thrown in `extract_from_element_strings` when passing a no bracket element string ending with a fixed length identifier (ex. `element_string = "0100614141123452"`).

I added a simple check to ensure that the `cursor` doesn't equal or exceed the `element_string_length` before attempting to check if the next character is a `group_separator`.